### PR TITLE
Fix temp ZIP file accumulation causing /tmp disk exhaustion

### DIFF
--- a/RELEASE_NOTES_1.0.3.md
+++ b/RELEASE_NOTES_1.0.3.md
@@ -1,0 +1,17 @@
+## Release Notes — TA-cveicu v1.0.3
+
+### Fix: Temp ZIP File Cleanup Preventing /tmp Disk Exhaustion
+
+Temporary ZIP files downloaded during CVE processing were not being cleaned up, causing `/tmp` to fill up on Splunk Cloud Search Heads over time.
+
+**What was broken:** The `download_release_asset()` method creates temp files via `tempfile.mkstemp(suffix='.zip')` for both baseline and delta ZIP downloads. Neither `_process_baseline` nor `_process_deltas` deleted these files after processing. On Splunk Cloud with hourly delta runs, thousands of ZIPs accumulated in `/tmp`, eventually causing critical disk utilization.
+
+**What changed:**
+
+- Added `try/finally` cleanup blocks in `_process_baseline` to delete the temp ZIP after baseline processing
+- Added `try/finally` cleanup blocks in `_process_deltas` to delete each temp ZIP after delta processing
+- Cleanup occurs on both success and error paths, matching the existing pattern used for nested ZIP cleanup in `github_client.py`
+
+**Reported via:** Splunk Support Case #4012420
+
+**Upgrade notes:** No manual steps required. After installing 1.0.3, temp files will be automatically cleaned up after each processing run. Any existing accumulated ZIP files in `/tmp` from prior versions should be manually removed or will be cleared on the next system restart.

--- a/TA-cveicu/README.md
+++ b/TA-cveicu/README.md
@@ -234,11 +234,12 @@ Splunk Index                          Enrichment Lookups
 
 ## Version History
 
-| Version | Date       | Changes                                            |
-| ------- | ---------- | -------------------------------------------------- |
-| 1.0.2   | 2026-04-05 | Fix EPSS/KEV lookup refresh on Splunk Cloud        |
-| 1.0.1   | 2026-02-16 | Remove upper bound from Splunk version requirement |
-| 1.0.0   | 2026-01-22 | Initial release                                    |
+| Version | Date       | Changes                                                   |
+| ------- | ---------- | --------------------------------------------------------- |
+| 1.0.3   | 2026-04-06 | Fix temp ZIP file cleanup preventing /tmp disk exhaustion |
+| 1.0.2   | 2026-04-05 | Fix EPSS/KEV lookup refresh on Splunk Cloud               |
+| 1.0.1   | 2026-02-16 | Remove upper bound from Splunk version requirement        |
+| 1.0.0   | 2026-01-22 | Initial release                                           |
 
 ## License
 

--- a/TA-cveicu/app.manifest
+++ b/TA-cveicu/app.manifest
@@ -5,7 +5,7 @@
     "id": {
       "group": null,
       "name": "TA-cveicu",
-      "version": "1.0.2"
+      "version": "1.0.3"
     },
     "author": [
       {
@@ -14,7 +14,7 @@
         "company": "cve.icu"
       }
     ],
-    "releaseDate": "2026-04-05",
+    "releaseDate": "2026-04-06",
     "description": "Ingest the complete CVE database (300K+ vulnerabilities) from the official CVE Program GitHub repository. Features efficient bulk downloads, incremental updates, CVSS scoring, CWE classification, and real-time vulnerability intelligence dashboards powered by cve.icu.",
     "classification": {
       "intendedAudience": "Security",

--- a/TA-cveicu/bin/cveicu.py
+++ b/TA-cveicu/bin/cveicu.py
@@ -19,13 +19,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "lib"))
 sys.path.insert(0, os.path.dirname(__file__))
 
 try:
-    from splunklib.modularinput import (
-        Script,
-        Scheme,
-        Argument,
-        Event,
-        EventWriter
-    )
+    from splunklib.modularinput import Script, Scheme, Argument, Event, EventWriter
 except ImportError:
     # Fallback for testing
     Script = object
@@ -45,31 +39,31 @@ from cveicu_lib.resource_manager import ResourceManager, TimeoutManager
 class CVEListV5Input(Script):
     """
     Splunk Modular Input for CVE List V5 data ingestion.
-    
+
     This modular input downloads CVE V5 records from GitHub releases:
     - Initial load uses the baseline ZIP (full export)
     - Subsequent runs use hourly delta ZIPs for incremental updates
     """
-    
+
     MASK = "********"
     APP_NAME = "TA-cveicu"
-    
+
     def __init__(self):
         super().__init__()
         self.logger = None
         self.resource_manager = None
         self.timeout_manager = None
-    
+
     def get_scheme(self) -> Optional[Scheme]:
         """
         Define the modular input scheme.
-        
+
         Returns:
             Scheme object describing input configuration
         """
         if Scheme is None:
             return None
-        
+
         scheme = Scheme("CVE List V5")
         scheme.title = "CVE List V5"
         scheme.description = (
@@ -79,9 +73,9 @@ class CVEListV5Input(Script):
         scheme.use_external_validation = False
         scheme.streaming_mode = Scheme.streaming_mode_xml
         scheme.use_single_instance = False
-        
+
         # Note: 'index' is handled internally by Splunk, not defined in scheme
-        
+
         # Include ADP data
         include_adp_arg = Argument("include_adp")
         include_adp_arg.title = "Include ADP Data"
@@ -93,7 +87,7 @@ class CVEListV5Input(Script):
         include_adp_arg.required_on_create = False
         include_adp_arg.required_on_edit = False
         scheme.add_argument(include_adp_arg)
-        
+
         # Include rejected CVEs
         include_rejected_arg = Argument("include_rejected")
         include_rejected_arg.title = "Include Rejected CVEs"
@@ -102,34 +96,36 @@ class CVEListV5Input(Script):
         include_rejected_arg.required_on_create = False
         include_rejected_arg.required_on_edit = False
         scheme.add_argument(include_rejected_arg)
-        
+
         # Batch size for event writing
         batch_size_arg = Argument("batch_size")
         batch_size_arg.title = "Batch Size"
-        batch_size_arg.description = "Number of CVE records to process per batch (default: 500)"
+        batch_size_arg.description = (
+            "Number of CVE records to process per batch (default: 500)"
+        )
         batch_size_arg.data_type = Argument.data_type_number
         batch_size_arg.required_on_create = False
         batch_size_arg.required_on_edit = False
         scheme.add_argument(batch_size_arg)
-        
+
         return scheme
-    
+
     def validate_input(self, validation_definition):
         """
         Validate input configuration.
-        
+
         Args:
             validation_definition: ValidationDefinition with stanza params
         """
         # Basic validation - check index exists (Splunk handles this)
         pass
-    
+
     def stream_events(self, inputs, ew: EventWriter) -> None:
         """
         Stream CVE events to Splunk.
-        
+
         This is the main entry point for the modular input.
-        
+
         Args:
             inputs: InputDefinition with configuration
             ew: EventWriter for writing events to Splunk
@@ -137,17 +133,17 @@ class CVEListV5Input(Script):
         # Initialize logging
         self.logger = setup_logging("stream_events")
         self.logger.info("CVE List V5 modular input starting")
-        
+
         # Get Splunk metadata
         server_host = inputs.metadata.get("server_host", "localhost")
         server_uri = inputs.metadata.get("server_uri", "https://localhost:8089")
         session_key = inputs.metadata.get("session_key")
-        
+
         if not session_key:
             self.logger.error("No session key available")
             self._write_error_event(ew, "No session key available", "startup")
             return
-        
+
         # Process each input stanza
         for input_name, input_config in inputs.inputs.items():
             try:
@@ -157,13 +153,13 @@ class CVEListV5Input(Script):
                     server_uri=server_uri,
                     session_key=session_key,
                     server_host=server_host,
-                    ew=ew
+                    ew=ew,
                 )
             except Exception as e:
                 self.logger.error(f"Fatal error processing {input_name}: {e}")
                 self.logger.error(traceback.format_exc())
                 self._write_error_event(ew, str(e), input_name)
-    
+
     def _process_input(
         self,
         input_name: str,
@@ -171,11 +167,11 @@ class CVEListV5Input(Script):
         server_uri: str,
         session_key: str,
         server_host: str,
-        ew: EventWriter
+        ew: EventWriter,
     ) -> None:
         """
         Process a single input stanza.
-        
+
         Args:
             input_name: Name of the input stanza
             input_config: Configuration dictionary
@@ -187,59 +183,56 @@ class CVEListV5Input(Script):
         # Extract configuration
         index = input_config.get("index", "main")
         include_adp = self._str_to_bool(input_config.get("include_adp", "true"))
-        include_rejected = self._str_to_bool(input_config.get("include_rejected", "true"))
+        include_rejected = self._str_to_bool(
+            input_config.get("include_rejected", "true")
+        )
         batch_size = int(input_config.get("batch_size", "500"))
-        
+
         self.logger.info(
             f"Processing input: {input_name}, index={index}, "
             f"include_adp={include_adp}, include_rejected={include_rejected}"
         )
-        
+
         # Initialize resource management
         self.resource_manager = ResourceManager(max_memory_mb=512, logger=self.logger)
         self.timeout_manager = TimeoutManager(timeout_seconds=3600, logger=self.logger)
-        
+
         # Write audit event for start
         self._write_audit_event(ew, "Input started", input_name, index)
-        
+
         # Get GitHub token from credential manager
         cred_manager = CredentialManager(
-            session_key=session_key,
-            splunk_uri=server_uri,
-            logger=self.logger
+            session_key=session_key, splunk_uri=server_uri, logger=self.logger
         )
         github_token = cred_manager.get_github_token()
-        
+
         if not github_token:
             self.logger.warning(
                 "No GitHub token configured - using unauthenticated API (60 req/hr limit)"
             )
-        
+
         # Initialize components
-        github_client = GitHubClient(
-            github_token=github_token,
-            logger=self.logger
-        )
-        
+        github_client = GitHubClient(github_token=github_token, logger=self.logger)
+
         checkpoint_manager = CheckpointManager(
             input_name=input_name,
             session_key=session_key,
             splunk_uri=server_uri,
-            logger=self.logger
+            logger=self.logger,
         )
-        
+
         cve_processor = CVEProcessor(
             input_name=input_name,
             index=index,
             include_adp=include_adp,
             include_rejected=include_rejected,
-            logger=self.logger
+            logger=self.logger,
         )
-        
+
         # Get current checkpoint
         checkpoint = checkpoint_manager.get_checkpoint()
         self.logger.info(f"Current checkpoint: {checkpoint}")
-        
+
         # Determine processing mode
         if checkpoint_manager.is_initial_load_needed():
             self.logger.info("Initial load needed - downloading baseline release")
@@ -248,7 +241,7 @@ class CVEListV5Input(Script):
                 checkpoint_manager=checkpoint_manager,
                 cve_processor=cve_processor,
                 batch_size=batch_size,
-                ew=ew
+                ew=ew,
             )
         else:
             self.logger.info("Incremental update - downloading delta releases")
@@ -257,31 +250,31 @@ class CVEListV5Input(Script):
                 checkpoint_manager=checkpoint_manager,
                 cve_processor=cve_processor,
                 batch_size=batch_size,
-                ew=ew
+                ew=ew,
             )
-        
+
         # Write completion audit event
         stats = cve_processor.get_stats()
         self._write_audit_event(
             ew,
             f"Input completed - processed: {stats['processed']}, skipped: {stats['skipped']}, errors: {stats['errors']}",
             input_name,
-            index
+            index,
         )
-        
+
         self.logger.info(f"Input {input_name} completed: {stats}")
-    
+
     def _process_baseline(
         self,
         github_client: GitHubClient,
         checkpoint_manager: CheckpointManager,
         cve_processor: CVEProcessor,
         batch_size: int,
-        ew: EventWriter
+        ew: EventWriter,
     ) -> None:
         """
         Process the baseline (full) release.
-        
+
         Args:
             github_client: GitHub API client
             checkpoint_manager: Checkpoint persistence manager
@@ -291,25 +284,28 @@ class CVEListV5Input(Script):
         """
         # Find baseline release
         baseline = github_client.find_baseline_release()
-        
+
         if not baseline:
             self.logger.error("No baseline release found")
             self._write_error_event(ew, "No baseline release found", "baseline")
             return
-        
+
         release_tag = baseline.get("tag_name", "unknown")
         self.logger.info(f"Processing baseline release: {release_tag}")
-        
+
         # Check if baseline was already substantially processed (resumable checkpoint)
         # This handles the case where baseline processing timed out after processing most records
         existing_checkpoint = checkpoint_manager.get_checkpoint()
         existing_records = existing_checkpoint.get("total_records_processed", 0)
         existing_tag = existing_checkpoint.get("last_release_tag", "")
-        
+
         # If we've already processed >300K records for this same release tag,
         # consider baseline complete and skip to delta processing
         BASELINE_COMPLETION_THRESHOLD = 300000
-        if existing_tag == release_tag and existing_records >= BASELINE_COMPLETION_THRESHOLD:
+        if (
+            existing_tag == release_tag
+            and existing_records >= BASELINE_COMPLETION_THRESHOLD
+        ):
             self.logger.info(
                 f"Baseline already substantially processed ({existing_records} records for {release_tag}). "
                 f"Marking initial load complete and switching to delta mode."
@@ -318,16 +314,16 @@ class CVEListV5Input(Script):
                 last_release_tag=release_tag,
                 last_cve_date_updated=existing_checkpoint.get("last_cve_date_updated"),
                 records_processed=existing_records,
-                initial_load_completed=True
+                initial_load_completed=True,
             )
             self._write_audit_event(
                 ew,
                 f"Baseline marked complete after resume detection: {existing_records} records",
                 "cveicu_input",
-                "main"
+                "main",
             )
             return
-        
+
         # Find all_CVEs_at_midnight.zip asset
         all_cves_asset = None
         for asset in baseline.get("assets", []):
@@ -335,79 +331,88 @@ class CVEListV5Input(Script):
             if "all_CVEs_at_midnight" in asset_name and asset_name.endswith(".zip"):
                 all_cves_asset = asset
                 break
-        
+
         if not all_cves_asset:
             self.logger.error("No all_CVEs_at_midnight.zip found in baseline release")
             self._write_error_event(ew, "No all_CVEs_at_midnight.zip found", "baseline")
             return
-        
+
         download_url = all_cves_asset.get("browser_download_url")
         self.logger.info(f"Downloading baseline: {download_url}")
-        
+
         # Download and stream ZIP contents
         zip_content = github_client.download_release_asset(download_url)
-        
+
         if not zip_content:
             self.logger.error("Failed to download baseline ZIP")
             self._write_error_event(ew, "Failed to download baseline ZIP", "baseline")
             return
-        
-        # Process CVEs in batches
-        batch = []
-        total_events = 0
-        
-        for filename, cve_data in github_client.stream_zip_contents(zip_content):
-            # Check resource limits
-            if not self.resource_manager.check_memory_usage():
-                self.logger.warning("Memory pressure detected, forcing GC")
-                # Memory cleanup is automatic in check_memory_usage
-            
-            if not self.timeout_manager.check_timeout():
-                self.logger.warning("Timeout approaching, saving checkpoint and exiting")
-                break
-            
-            batch.append(cve_data)
-            
-            if len(batch) >= batch_size:
+
+        try:
+            # Process CVEs in batches
+            batch = []
+            total_events = 0
+
+            for filename, cve_data in github_client.stream_zip_contents(zip_content):
+                # Check resource limits
+                if not self.resource_manager.check_memory_usage():
+                    self.logger.warning("Memory pressure detected, forcing GC")
+                    # Memory cleanup is automatic in check_memory_usage
+
+                if not self.timeout_manager.check_timeout():
+                    self.logger.warning(
+                        "Timeout approaching, saving checkpoint and exiting"
+                    )
+                    break
+
+                batch.append(cve_data)
+
+                if len(batch) >= batch_size:
+                    events_written = self._write_batch(batch, cve_processor, ew)
+                    total_events += events_written
+                    batch = []
+
+                    # Save checkpoint periodically
+                    if total_events % 10000 == 0:
+                        self.logger.info(f"Progress: {total_events} events written")
+                        checkpoint_manager.save_checkpoint(
+                            last_release_tag=release_tag,
+                            last_cve_date_updated=cve_processor.max_date_updated,
+                            records_processed=total_events,
+                        )
+
+            # Process remaining batch
+            if batch:
                 events_written = self._write_batch(batch, cve_processor, ew)
                 total_events += events_written
-                batch = []
-                
-                # Save checkpoint periodically
-                if total_events % 10000 == 0:
-                    self.logger.info(f"Progress: {total_events} events written")
-                    checkpoint_manager.save_checkpoint(
-                        last_release_tag=release_tag,
-                        last_cve_date_updated=cve_processor.max_date_updated,
-                        records_processed=total_events
-                    )
-        
-        # Process remaining batch
-        if batch:
-            events_written = self._write_batch(batch, cve_processor, ew)
-            total_events += events_written
-        
-        # Save final checkpoint
-        checkpoint_manager.save_checkpoint(
-            last_release_tag=release_tag,
-            last_cve_date_updated=cve_processor.max_date_updated,
-            records_processed=total_events,
-            initial_load_completed=True
-        )
-        
-        self.logger.info(f"Baseline processing complete: {total_events} events")
-    
+
+            # Save final checkpoint
+            checkpoint_manager.save_checkpoint(
+                last_release_tag=release_tag,
+                last_cve_date_updated=cve_processor.max_date_updated,
+                records_processed=total_events,
+                initial_load_completed=True,
+            )
+
+            self.logger.info(f"Baseline processing complete: {total_events} events")
+        finally:
+            try:
+                os.unlink(zip_content)
+                self.logger.debug(f"Cleaned up temp file: {zip_content}")
+            except OSError:
+                pass
+
     def _process_deltas(
         self,
         github_client: GitHubClient,
         checkpoint_manager: CheckpointManager,
         cve_processor: CVEProcessor,
         batch_size: int,
-        ew: EventWriter
+        ew: EventWriter,
     ) -> None:
         """
         Process delta (incremental) releases.
-        
+
         Args:
             github_client: GitHub API client
             checkpoint_manager: Checkpoint persistence manager
@@ -417,26 +422,26 @@ class CVEListV5Input(Script):
         """
         checkpoint = checkpoint_manager.get_checkpoint()
         last_release = checkpoint.get("last_release")
-        
+
         # Find delta releases since last checkpoint
         deltas = github_client.find_delta_releases_since(last_release)
-        
+
         if not deltas:
             self.logger.info("No new delta releases found")
             return
-        
+
         self.logger.info(f"Found {len(deltas)} delta releases to process")
-        
+
         total_events = 0
-        
+
         for delta in deltas:
             if not self.timeout_manager.check_timeout():
                 self.logger.warning("Timeout approaching, stopping delta processing")
                 break
-            
+
             release_tag = delta.get("tag_name", "unknown")
             self.logger.info(f"Processing delta: {release_tag}")
-            
+
             # Find deltaCves.zip asset
             delta_asset = None
             for asset in delta.get("assets", []):
@@ -444,62 +449,59 @@ class CVEListV5Input(Script):
                 if "deltaCves" in name or "delta" in name.lower():
                     delta_asset = asset
                     break
-            
+
             if not delta_asset:
                 self.logger.warning(f"No delta ZIP found in {release_tag}")
                 continue
-            
+
             download_url = delta_asset.get("browser_download_url")
             zip_content = github_client.download_release_asset(download_url)
-            
+
             if not zip_content:
                 self.logger.warning(f"Failed to download delta: {release_tag}")
                 continue
-            
+
             # Process CVEs
             batch = []
-            
+
             for filename, cve_data in github_client.stream_zip_contents(zip_content):
                 # Only process if newer than checkpoint
                 cve_id = cve_data.get("cveMetadata", {}).get("cveId", "")
                 date_updated = cve_data.get("cveMetadata", {}).get("dateUpdated")
-                
+
                 if checkpoint_manager.should_process_cve(date_updated):
                     batch.append(cve_data)
-                
+
                 if len(batch) >= batch_size:
                     events_written = self._write_batch(batch, cve_processor, ew)
                     total_events += events_written
                     batch = []
-            
+
             # Process remaining batch
             if batch:
                 events_written = self._write_batch(batch, cve_processor, ew)
                 total_events += events_written
-            
+
             # Update checkpoint for each processed delta
             checkpoint_manager.save_checkpoint(
                 last_release_tag=release_tag,
                 last_cve_date_updated=cve_processor.max_date_updated,
-                records_processed=total_events
+                records_processed=total_events,
             )
-        
+
         self.logger.info(f"Delta processing complete: {total_events} events")
-    
+
     def _write_batch(
-        self,
-        batch: list,
-        cve_processor: CVEProcessor,
-        ew: EventWriter
+        self, batch: list, cve_processor: CVEProcessor, ew: EventWriter
     ) -> int:
         """
         Write a batch of events to Splunk.
-        
+
         Args:
             batch: List of raw CVE data
             cve_processor: CVE processor instance
             ew: EventWriter
-            
+
         Returns:
             Number of events written
         """
@@ -512,35 +514,28 @@ class CVEListV5Input(Script):
                 except Exception as e:
                     self.logger.error(f"Error writing event: {e}")
         return count
-    
-    def _write_error_event(
-        self,
-        ew: EventWriter,
-        message: str,
-        context: str
-    ) -> None:
+
+    def _write_error_event(self, ew: EventWriter, message: str, context: str) -> None:
         """Write an error event."""
         try:
             event = Event()
             event.stanza = context
             event.sourceType = "cveicu:error"
-            event.data = json.dumps({
-                "level": "ERROR",
-                "message": message,
-                "context": context,
-                "timestamp": datetime.utcnow().isoformat() + "Z"
-            })
+            event.data = json.dumps(
+                {
+                    "level": "ERROR",
+                    "message": message,
+                    "context": context,
+                    "timestamp": datetime.utcnow().isoformat() + "Z",
+                }
+            )
             ew.write_event(event)
         except Exception as e:
             if self.logger:
                 self.logger.error(f"Failed to write error event: {e}")
-    
+
     def _write_audit_event(
-        self,
-        ew: EventWriter,
-        message: str,
-        input_name: str,
-        index: str
+        self, ew: EventWriter, message: str, input_name: str, index: str
     ) -> None:
         """Write an audit event."""
         try:
@@ -548,17 +543,19 @@ class CVEListV5Input(Script):
             event.stanza = input_name
             event.sourceType = "cveicu:audit"
             event.index = index
-            event.data = json.dumps({
-                "level": "INFO",
-                "message": message,
-                "input_name": input_name,
-                "timestamp": datetime.utcnow().isoformat() + "Z"
-            })
+            event.data = json.dumps(
+                {
+                    "level": "INFO",
+                    "message": message,
+                    "input_name": input_name,
+                    "timestamp": datetime.utcnow().isoformat() + "Z",
+                }
+            )
             ew.write_event(event)
         except Exception as e:
             if self.logger:
                 self.logger.error(f"Failed to write audit event: {e}")
-    
+
     @staticmethod
     def _str_to_bool(value: str) -> bool:
         """Convert string to boolean."""

--- a/TA-cveicu/bin/cveicu.py
+++ b/TA-cveicu/bin/cveicu.py
@@ -461,33 +461,42 @@ class CVEListV5Input(Script):
                 self.logger.warning(f"Failed to download delta: {release_tag}")
                 continue
 
-            # Process CVEs
-            batch = []
+            try:
+                # Process CVEs
+                batch = []
 
-            for filename, cve_data in github_client.stream_zip_contents(zip_content):
-                # Only process if newer than checkpoint
-                cve_id = cve_data.get("cveMetadata", {}).get("cveId", "")
-                date_updated = cve_data.get("cveMetadata", {}).get("dateUpdated")
+                for filename, cve_data in github_client.stream_zip_contents(
+                    zip_content
+                ):
+                    # Only process if newer than checkpoint
+                    cve_id = cve_data.get("cveMetadata", {}).get("cveId", "")
+                    date_updated = cve_data.get("cveMetadata", {}).get("dateUpdated")
 
-                if checkpoint_manager.should_process_cve(date_updated):
-                    batch.append(cve_data)
+                    if checkpoint_manager.should_process_cve(date_updated):
+                        batch.append(cve_data)
 
-                if len(batch) >= batch_size:
+                    if len(batch) >= batch_size:
+                        events_written = self._write_batch(batch, cve_processor, ew)
+                        total_events += events_written
+                        batch = []
+
+                # Process remaining batch
+                if batch:
                     events_written = self._write_batch(batch, cve_processor, ew)
                     total_events += events_written
-                    batch = []
 
-            # Process remaining batch
-            if batch:
-                events_written = self._write_batch(batch, cve_processor, ew)
-                total_events += events_written
-
-            # Update checkpoint for each processed delta
-            checkpoint_manager.save_checkpoint(
-                last_release_tag=release_tag,
-                last_cve_date_updated=cve_processor.max_date_updated,
-                records_processed=total_events,
-            )
+                # Update checkpoint for each processed delta
+                checkpoint_manager.save_checkpoint(
+                    last_release_tag=release_tag,
+                    last_cve_date_updated=cve_processor.max_date_updated,
+                    records_processed=total_events,
+                )
+            finally:
+                try:
+                    os.unlink(zip_content)
+                    self.logger.debug(f"Cleaned up temp file: {zip_content}")
+                except OSError:
+                    pass
 
         self.logger.info(f"Delta processing complete: {total_events} events")
 

--- a/TA-cveicu/default/app.conf
+++ b/TA-cveicu/default/app.conf
@@ -4,11 +4,11 @@
 [install]
 is_configured = 0
 state = enabled
-build = 3
+build = 4
 
 [id]
 name = TA-cveicu
-version = 1.0.2
+version = 1.0.3
 
 [package]
 id = TA-cveicu
@@ -17,7 +17,7 @@ check_for_updates = true
 [launcher]
 author = cve.icu
 description = Ingest and analyze CVE (Common Vulnerabilities and Exposures) records from the official CVE Program repository. Features bulk baseline downloads, hourly delta updates, CVSS scoring, CISA-ADP enrichment, and comprehensive vulnerability dashboards.
-version = 1.0.2
+version = 1.0.3
 
 [ui]
 is_visible = true

--- a/docs/superpowers/plans/2026-04-06-tmp-zip-cleanup.md
+++ b/docs/superpowers/plans/2026-04-06-tmp-zip-cleanup.md
@@ -1,0 +1,530 @@
+# Temp ZIP File Cleanup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix temp ZIP file accumulation in `/tmp` that causes disk exhaustion on Splunk Cloud Search Heads.
+
+**Architecture:** Add `try/finally` cleanup blocks around ZIP processing in both `_process_baseline` and `_process_deltas` methods in `cveicu.py`. Tests verify cleanup happens on both success and error paths.
+
+**Tech Stack:** Python 3, pytest, unittest.mock
+
+---
+
+### Task 1: Write tests for baseline ZIP cleanup
+
+**Files:**
+
+- Create: `tests/unit/test_zip_cleanup.py`
+
+- [ ] **Step 1: Create test file with baseline cleanup tests**
+
+```python
+"""Unit tests for temp ZIP file cleanup in cveicu.py."""
+
+import os
+import tempfile
+import json
+import zipfile
+from unittest.mock import MagicMock, patch, PropertyMock
+
+import pytest
+
+
+def _make_temp_zip():
+    """Create a real temp ZIP file with a minimal CVE JSON inside."""
+    fd, path = tempfile.mkstemp(suffix=".zip")
+    with os.fdopen(fd, "wb") as f:
+        with zipfile.ZipFile(f, "w") as zf:
+            cve = {
+                "cveMetadata": {
+                    "cveId": "CVE-2024-0001",
+                    "dateUpdated": "2024-01-01T00:00:00Z",
+                },
+            }
+            zf.writestr("CVE-2024-0001.json", json.dumps(cve))
+    return path
+
+
+def _make_input_instance():
+    """Create a CVEListV5Input with mocked dependencies."""
+    # Patch splunklib imports before importing cveicu
+    import sys
+    from unittest.mock import MagicMock
+
+    # Ensure splunklib.modularinput is mockable
+    if "splunklib" not in sys.modules:
+        sys.modules["splunklib"] = MagicMock()
+        sys.modules["splunklib.modularinput"] = MagicMock()
+
+    from cveicu import CVEListV5Input
+
+    instance = CVEListV5Input.__new__(CVEListV5Input)
+    instance.logger = MagicMock()
+    instance.resource_manager = MagicMock()
+    instance.resource_manager.check_memory_usage.return_value = True
+    instance.timeout_manager = MagicMock()
+    instance.timeout_manager.check_timeout.return_value = True
+    return instance
+
+
+class TestBaselineZipCleanup:
+    def test_zip_deleted_after_successful_processing(self):
+        """Temp ZIP must be deleted after baseline processes successfully."""
+        zip_path = _make_temp_zip()
+        assert os.path.exists(zip_path)
+
+        instance = _make_input_instance()
+        github_client = MagicMock()
+        checkpoint_manager = MagicMock()
+        cve_processor = MagicMock()
+        ew = MagicMock()
+
+        # find_baseline_release returns a release with the right asset
+        github_client.find_baseline_release.return_value = {
+            "tag_name": "cve_2024-01-01_0000Z",
+            "assets": [
+                {
+                    "name": "all_CVEs_at_midnight.zip",
+                    "browser_download_url": "https://example.com/all.zip",
+                }
+            ],
+        }
+        checkpoint_manager.is_initial_load_needed.return_value = True
+        checkpoint_manager.get_checkpoint.return_value = {}
+        github_client.download_release_asset.return_value = zip_path
+        github_client.stream_zip_contents.return_value = iter([])
+        cve_processor.get_stats.return_value = {"processed": 0, "skipped": 0, "errors": 0}
+        cve_processor.max_date_updated = None
+
+        instance._process_baseline(
+            github_client=github_client,
+            checkpoint_manager=checkpoint_manager,
+            cve_processor=cve_processor,
+            batch_size=500,
+            ew=ew,
+        )
+
+        assert not os.path.exists(zip_path), "Temp ZIP was not deleted after successful baseline processing"
+
+    def test_zip_deleted_when_processing_raises(self):
+        """Temp ZIP must be deleted even when processing throws an exception."""
+        zip_path = _make_temp_zip()
+        assert os.path.exists(zip_path)
+
+        instance = _make_input_instance()
+        github_client = MagicMock()
+        checkpoint_manager = MagicMock()
+        cve_processor = MagicMock()
+        ew = MagicMock()
+
+        github_client.find_baseline_release.return_value = {
+            "tag_name": "cve_2024-01-01_0000Z",
+            "assets": [
+                {
+                    "name": "all_CVEs_at_midnight.zip",
+                    "browser_download_url": "https://example.com/all.zip",
+                }
+            ],
+        }
+        checkpoint_manager.is_initial_load_needed.return_value = True
+        checkpoint_manager.get_checkpoint.return_value = {}
+        github_client.download_release_asset.return_value = zip_path
+        github_client.stream_zip_contents.side_effect = RuntimeError("corrupt zip")
+
+        with pytest.raises(RuntimeError, match="corrupt zip"):
+            instance._process_baseline(
+                github_client=github_client,
+                checkpoint_manager=checkpoint_manager,
+                cve_processor=cve_processor,
+                batch_size=500,
+                ew=ew,
+            )
+
+        assert not os.path.exists(zip_path), "Temp ZIP was not deleted after baseline processing error"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/gamblin/Documents/Github/SplunkCVEList && python -m pytest tests/unit/test_zip_cleanup.py::TestBaselineZipCleanup -v`
+
+Expected: Both tests FAIL — the first because the file still exists after processing, the second because the exception propagates but cleanup doesn't happen.
+
+- [ ] **Step 3: Commit test file**
+
+```bash
+git add tests/unit/test_zip_cleanup.py
+git commit -m "test: add failing tests for baseline ZIP cleanup"
+```
+
+---
+
+### Task 2: Implement baseline ZIP cleanup
+
+**Files:**
+
+- Modify: `TA-cveicu/bin/cveicu.py:347-398`
+
+- [ ] **Step 1: Add try/finally around baseline ZIP processing**
+
+In `_process_baseline`, wrap lines 355-398 (everything after the download and null-check) in a `try/finally` block that deletes the temp file:
+
+Replace this block (lines 355-398):
+
+```python
+        # Process CVEs in batches
+        batch = []
+        total_events = 0
+
+        for filename, cve_data in github_client.stream_zip_contents(zip_content):
+            # Check resource limits
+            if not self.resource_manager.check_memory_usage():
+                self.logger.warning("Memory pressure detected, forcing GC")
+                # Memory cleanup is automatic in check_memory_usage
+
+            if not self.timeout_manager.check_timeout():
+                self.logger.warning("Timeout approaching, saving checkpoint and exiting")
+                break
+
+            batch.append(cve_data)
+
+            if len(batch) >= batch_size:
+                events_written = self._write_batch(batch, cve_processor, ew)
+                total_events += events_written
+                batch = []
+
+                # Save checkpoint periodically
+                if total_events % 10000 == 0:
+                    self.logger.info(f"Progress: {total_events} events written")
+                    checkpoint_manager.save_checkpoint(
+                        last_release_tag=release_tag,
+                        last_cve_date_updated=cve_processor.max_date_updated,
+                        records_processed=total_events
+                    )
+
+        # Process remaining batch
+        if batch:
+            events_written = self._write_batch(batch, cve_processor, ew)
+            total_events += events_written
+
+        # Save final checkpoint
+        checkpoint_manager.save_checkpoint(
+            last_release_tag=release_tag,
+            last_cve_date_updated=cve_processor.max_date_updated,
+            records_processed=total_events,
+            initial_load_completed=True
+        )
+
+        self.logger.info(f"Baseline processing complete: {total_events} events")
+```
+
+With:
+
+```python
+        # Process CVEs in batches, ensuring temp ZIP is cleaned up
+        try:
+            batch = []
+            total_events = 0
+
+            for filename, cve_data in github_client.stream_zip_contents(zip_content):
+                # Check resource limits
+                if not self.resource_manager.check_memory_usage():
+                    self.logger.warning("Memory pressure detected, forcing GC")
+                    # Memory cleanup is automatic in check_memory_usage
+
+                if not self.timeout_manager.check_timeout():
+                    self.logger.warning("Timeout approaching, saving checkpoint and exiting")
+                    break
+
+                batch.append(cve_data)
+
+                if len(batch) >= batch_size:
+                    events_written = self._write_batch(batch, cve_processor, ew)
+                    total_events += events_written
+                    batch = []
+
+                    # Save checkpoint periodically
+                    if total_events % 10000 == 0:
+                        self.logger.info(f"Progress: {total_events} events written")
+                        checkpoint_manager.save_checkpoint(
+                            last_release_tag=release_tag,
+                            last_cve_date_updated=cve_processor.max_date_updated,
+                            records_processed=total_events
+                        )
+
+            # Process remaining batch
+            if batch:
+                events_written = self._write_batch(batch, cve_processor, ew)
+                total_events += events_written
+
+            # Save final checkpoint
+            checkpoint_manager.save_checkpoint(
+                last_release_tag=release_tag,
+                last_cve_date_updated=cve_processor.max_date_updated,
+                records_processed=total_events,
+                initial_load_completed=True
+            )
+
+            self.logger.info(f"Baseline processing complete: {total_events} events")
+        finally:
+            try:
+                os.unlink(zip_content)
+                self.logger.debug(f"Cleaned up temp file: {zip_content}")
+            except OSError:
+                pass
+```
+
+- [ ] **Step 2: Run baseline tests to verify they pass**
+
+Run: `cd /Users/gamblin/Documents/Github/SplunkCVEList && python -m pytest tests/unit/test_zip_cleanup.py::TestBaselineZipCleanup -v`
+
+Expected: Both tests PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add TA-cveicu/bin/cveicu.py
+git commit -m "fix: clean up temp ZIP after baseline processing"
+```
+
+---
+
+### Task 3: Write tests for delta ZIP cleanup
+
+**Files:**
+
+- Modify: `tests/unit/test_zip_cleanup.py`
+
+- [ ] **Step 1: Add delta cleanup tests to the test file**
+
+Append to `tests/unit/test_zip_cleanup.py`:
+
+```python
+class TestDeltaZipCleanup:
+    def test_zip_deleted_after_successful_delta(self):
+        """Temp ZIP must be deleted after each delta processes successfully."""
+        zip_path = _make_temp_zip()
+        assert os.path.exists(zip_path)
+
+        instance = _make_input_instance()
+        github_client = MagicMock()
+        checkpoint_manager = MagicMock()
+        cve_processor = MagicMock()
+        ew = MagicMock()
+
+        checkpoint_manager.get_checkpoint.return_value = {"last_release": "cve_2024-01-01_0100Z"}
+        github_client.find_delta_releases_since.return_value = [
+            {
+                "tag_name": "cve_2024-01-01_0200Z",
+                "assets": [{"name": "delta_CVEs_at_0200Z.zip", "browser_download_url": "https://example.com/delta.zip"}],
+            }
+        ]
+        github_client.download_release_asset.return_value = zip_path
+        github_client.stream_zip_contents.return_value = iter([])
+        cve_processor.max_date_updated = None
+
+        instance._process_deltas(
+            github_client=github_client,
+            checkpoint_manager=checkpoint_manager,
+            cve_processor=cve_processor,
+            batch_size=500,
+            ew=ew,
+        )
+
+        assert not os.path.exists(zip_path), "Temp ZIP was not deleted after successful delta processing"
+
+    def test_zip_deleted_when_delta_raises(self):
+        """Temp ZIP must be deleted even when delta processing throws."""
+        zip_path = _make_temp_zip()
+        assert os.path.exists(zip_path)
+
+        instance = _make_input_instance()
+        github_client = MagicMock()
+        checkpoint_manager = MagicMock()
+        cve_processor = MagicMock()
+        ew = MagicMock()
+
+        checkpoint_manager.get_checkpoint.return_value = {"last_release": "cve_2024-01-01_0100Z"}
+        github_client.find_delta_releases_since.return_value = [
+            {
+                "tag_name": "cve_2024-01-01_0200Z",
+                "assets": [{"name": "delta_CVEs_at_0200Z.zip", "browser_download_url": "https://example.com/delta.zip"}],
+            }
+        ]
+        github_client.download_release_asset.return_value = zip_path
+        github_client.stream_zip_contents.side_effect = RuntimeError("corrupt zip")
+
+        with pytest.raises(RuntimeError, match="corrupt zip"):
+            instance._process_deltas(
+                github_client=github_client,
+                checkpoint_manager=checkpoint_manager,
+                cve_processor=cve_processor,
+                batch_size=500,
+                ew=ew,
+            )
+
+        assert not os.path.exists(zip_path), "Temp ZIP was not deleted after delta processing error"
+
+    def test_all_zips_cleaned_in_multi_delta_run(self):
+        """All temp ZIPs must be cleaned up when processing multiple deltas."""
+        zip_paths = [_make_temp_zip() for _ in range(3)]
+        for p in zip_paths:
+            assert os.path.exists(p)
+
+        instance = _make_input_instance()
+        github_client = MagicMock()
+        checkpoint_manager = MagicMock()
+        cve_processor = MagicMock()
+        ew = MagicMock()
+
+        checkpoint_manager.get_checkpoint.return_value = {"last_release": "cve_2024-01-01_0100Z"}
+        github_client.find_delta_releases_since.return_value = [
+            {
+                "tag_name": f"cve_2024-01-01_0{i}00Z",
+                "assets": [{"name": f"delta_CVEs_at_0{i}00Z.zip", "browser_download_url": f"https://example.com/delta{i}.zip"}],
+            }
+            for i in range(2, 5)
+        ]
+        github_client.download_release_asset.side_effect = zip_paths
+        github_client.stream_zip_contents.return_value = iter([])
+        cve_processor.max_date_updated = None
+
+        instance._process_deltas(
+            github_client=github_client,
+            checkpoint_manager=checkpoint_manager,
+            cve_processor=cve_processor,
+            batch_size=500,
+            ew=ew,
+        )
+
+        for p in zip_paths:
+            assert not os.path.exists(p), f"Temp ZIP {p} was not deleted after multi-delta processing"
+```
+
+- [ ] **Step 2: Run delta tests to verify they fail**
+
+Run: `cd /Users/gamblin/Documents/Github/SplunkCVEList && python -m pytest tests/unit/test_zip_cleanup.py::TestDeltaZipCleanup -v`
+
+Expected: All three tests FAIL — files still exist after processing.
+
+- [ ] **Step 3: Commit test additions**
+
+```bash
+git add tests/unit/test_zip_cleanup.py
+git commit -m "test: add failing tests for delta ZIP cleanup"
+```
+
+---
+
+### Task 4: Implement delta ZIP cleanup
+
+**Files:**
+
+- Modify: `TA-cveicu/bin/cveicu.py:453-485`
+
+- [ ] **Step 1: Add try/finally around delta ZIP processing**
+
+In `_process_deltas`, wrap the per-delta processing block. Replace this code inside the `for delta in deltas:` loop (lines 453-485):
+
+```python
+            download_url = delta_asset.get("browser_download_url")
+            zip_content = github_client.download_release_asset(download_url)
+
+            if not zip_content:
+                self.logger.warning(f"Failed to download delta: {release_tag}")
+                continue
+
+            # Process CVEs
+            batch = []
+
+            for filename, cve_data in github_client.stream_zip_contents(zip_content):
+                # Only process if newer than checkpoint
+                cve_id = cve_data.get("cveMetadata", {}).get("cveId", "")
+                date_updated = cve_data.get("cveMetadata", {}).get("dateUpdated")
+
+                if checkpoint_manager.should_process_cve(date_updated):
+                    batch.append(cve_data)
+
+                if len(batch) >= batch_size:
+                    events_written = self._write_batch(batch, cve_processor, ew)
+                    total_events += events_written
+                    batch = []
+
+            # Process remaining batch
+            if batch:
+                events_written = self._write_batch(batch, cve_processor, ew)
+                total_events += events_written
+
+            # Update checkpoint for each processed delta
+            checkpoint_manager.save_checkpoint(
+                last_release_tag=release_tag,
+                last_cve_date_updated=cve_processor.max_date_updated,
+                records_processed=total_events
+            )
+```
+
+With:
+
+```python
+            download_url = delta_asset.get("browser_download_url")
+            zip_content = github_client.download_release_asset(download_url)
+
+            if not zip_content:
+                self.logger.warning(f"Failed to download delta: {release_tag}")
+                continue
+
+            # Process CVEs, ensuring temp ZIP is cleaned up
+            try:
+                batch = []
+
+                for filename, cve_data in github_client.stream_zip_contents(zip_content):
+                    # Only process if newer than checkpoint
+                    cve_id = cve_data.get("cveMetadata", {}).get("cveId", "")
+                    date_updated = cve_data.get("cveMetadata", {}).get("dateUpdated")
+
+                    if checkpoint_manager.should_process_cve(date_updated):
+                        batch.append(cve_data)
+
+                    if len(batch) >= batch_size:
+                        events_written = self._write_batch(batch, cve_processor, ew)
+                        total_events += events_written
+                        batch = []
+
+                # Process remaining batch
+                if batch:
+                    events_written = self._write_batch(batch, cve_processor, ew)
+                    total_events += events_written
+
+                # Update checkpoint for each processed delta
+                checkpoint_manager.save_checkpoint(
+                    last_release_tag=release_tag,
+                    last_cve_date_updated=cve_processor.max_date_updated,
+                    records_processed=total_events
+                )
+            finally:
+                try:
+                    os.unlink(zip_content)
+                    self.logger.debug(f"Cleaned up temp file: {zip_content}")
+                except OSError:
+                    pass
+```
+
+- [ ] **Step 2: Run all cleanup tests to verify they pass**
+
+Run: `cd /Users/gamblin/Documents/Github/SplunkCVEList && python -m pytest tests/unit/test_zip_cleanup.py -v`
+
+Expected: All 5 tests PASS
+
+- [ ] **Step 3: Run the full test suite to check for regressions**
+
+Run: `cd /Users/gamblin/Documents/Github/SplunkCVEList && python -m pytest tests/ -v`
+
+Expected: All existing tests still pass
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add TA-cveicu/bin/cveicu.py
+git commit -m "fix: clean up temp ZIP after delta processing
+
+Closes #4"
+```

--- a/docs/superpowers/specs/2026-04-06-tmp-zip-cleanup-design.md
+++ b/docs/superpowers/specs/2026-04-06-tmp-zip-cleanup-design.md
@@ -1,0 +1,47 @@
+# Temp ZIP File Cleanup Fix
+
+**Date:** 2026-04-06
+**Status:** Approved
+**Severity:** Critical (causes disk exhaustion on Splunk Cloud Search Heads)
+
+## Problem
+
+`download_release_asset()` in `github_client.py:302` creates temp files in `/tmp` via `tempfile.mkstemp(suffix='.zip')`. Neither `_process_baseline` nor `_process_deltas` in `cveicu.py` deletes these files after processing. On Splunk Cloud, hourly delta runs accumulate thousands of ZIPs, eventually filling the Search Head disk.
+
+**Reported via:** Splunk Support Case #4012420 — Search Head in the 'porter' stack reached critical disk utilization due to accumulated `.zip` files in `/tmp`.
+
+## Root Cause
+
+- `download_release_asset()` returns a file path to a temp `.zip` file
+- Callers in `cveicu.py` (`_process_baseline` line ~348, `_process_deltas` line ~453) use the file but never delete it
+- Nested ZIP cleanup in `stream_zip_contents()` (line 364-370) works correctly — the top-level downloads are the gap
+
+## Solution: Caller-side `try/finally` cleanup
+
+Wrap the download-process-cleanup cycle in `try/finally` blocks in both caller methods. This mirrors the existing cleanup pattern for nested ZIPs in `github_client.py`.
+
+### Changes
+
+**`cveicu.py` — `_process_baseline` (~line 345-398):**
+
+- Store the returned path from `download_release_asset()` in `zip_path`
+- Wrap `stream_zip_contents` iteration and batch processing in `try/finally`
+- In `finally`: delete file with `os.unlink(zip_path)`, wrapped in try/except to avoid masking errors
+- Log cleanup at debug level
+
+**`cveicu.py` — `_process_deltas` (~line 453-485):**
+
+- Same pattern: store `zip_path`, wrap processing in `try/finally`, delete in `finally`
+- Inside the `for delta in deltas` loop, so each delta ZIP is cleaned up before the next download
+
+### What doesn't change
+
+- `github_client.py` — no API changes
+- Nested ZIP cleanup in `stream_zip_contents` — already correct
+- No new dependencies, no config changes
+
+## Alternatives Considered
+
+**Context manager on `download_release_asset`:** More Pythonic but invasive — changes the API contract for a simple fix.
+
+**Tracked cleanup in `GitHubClient.close()`:** Keeps files alive too long and depends on `close()` being called, which is the same class of problem.

--- a/docs/superpowers/specs/2026-04-06-tmp-zip-cleanup-design.md
+++ b/docs/superpowers/specs/2026-04-06-tmp-zip-cleanup-design.md
@@ -40,6 +40,27 @@ Wrap the download-process-cleanup cycle in `try/finally` blocks in both caller m
 - Nested ZIP cleanup in `stream_zip_contents` — already correct
 - No new dependencies, no config changes
 
+## Tests
+
+Add a new test file `tests/test_zip_cleanup.py` with unit tests covering:
+
+**Baseline cleanup:**
+
+- Verify temp ZIP file is deleted after successful baseline processing
+- Verify temp ZIP file is deleted even when processing raises an exception
+
+**Delta cleanup:**
+
+- Verify temp ZIP file is deleted after each successful delta processing
+- Verify temp ZIP file is deleted even when a delta processing raises an exception
+- Verify all temp ZIPs are cleaned up when processing multiple deltas (loop iteration)
+
+**Test approach:**
+
+- Mock `GitHubClient` methods (`download_release_asset`, `stream_zip_contents`, etc.) and `CheckpointManager`/`CVEProcessor`/`EventWriter`
+- Use `tempfile.mkstemp` to create real temp files, pass their paths from the mocked `download_release_asset`
+- Assert `os.path.exists(zip_path)` is `False` after processing completes (both success and error paths)
+
 ## Alternatives Considered
 
 **Context manager on `download_release_asset`:** More Pythonic but invasive — changes the API contract for a simple fix.

--- a/tests/unit/test_zip_cleanup.py
+++ b/tests/unit/test_zip_cleanup.py
@@ -1,0 +1,141 @@
+"""Unit tests for temp ZIP file cleanup in cveicu.py."""
+
+import os
+import sys
+import json
+import zipfile
+from unittest.mock import MagicMock
+
+import pytest
+
+# Mock splunklib before importing cveicu
+if "splunklib" not in sys.modules:
+    mock_splunklib = MagicMock()
+    mock_modularinput = MagicMock()
+
+    # Create a proper base class for Script
+    class MockScript:
+        def __init__(self):
+            pass
+
+        def run(self, argv):
+            return 0
+
+    mock_modularinput.Script = MockScript
+    mock_modularinput.Scheme = None
+    mock_modularinput.Argument = None
+    mock_modularinput.Event = None
+    mock_modularinput.EventWriter = None
+
+    sys.modules["splunklib"] = mock_splunklib
+    sys.modules["splunklib.modularinput"] = mock_modularinput
+
+from cveicu import CVEListV5Input
+
+
+def _make_temp_zip(tmp_path):
+    """Create a real temp ZIP file with a minimal CVE JSON inside."""
+    path = str(tmp_path / "test.zip")
+    with zipfile.ZipFile(path, "w") as zf:
+        cve = {
+            "cveMetadata": {
+                "cveId": "CVE-2024-0001",
+                "dateUpdated": "2024-01-01T00:00:00Z",
+            },
+        }
+        zf.writestr("CVE-2024-0001.json", json.dumps(cve))
+    return path
+
+
+def _make_input_instance():
+    """Create a CVEListV5Input with mocked dependencies."""
+    instance = CVEListV5Input.__new__(CVEListV5Input)
+    instance.logger = MagicMock()
+    instance.resource_manager = MagicMock()
+    instance.resource_manager.check_memory_usage.return_value = True
+    instance.timeout_manager = MagicMock()
+    instance.timeout_manager.check_timeout.return_value = True
+    return instance
+
+
+class TestBaselineZipCleanup:
+    def test_zip_deleted_after_successful_processing(self, tmp_path):
+        """Temp ZIP must be deleted after baseline processes successfully."""
+        zip_path = _make_temp_zip(tmp_path)
+        assert os.path.exists(zip_path)
+
+        instance = _make_input_instance()
+        github_client = MagicMock()
+        checkpoint_manager = MagicMock()
+        cve_processor = MagicMock()
+        ew = MagicMock()
+
+        github_client.find_baseline_release.return_value = {
+            "tag_name": "cve_2024-01-01_0000Z",
+            "assets": [
+                {
+                    "name": "all_CVEs_at_midnight.zip",
+                    "browser_download_url": "https://example.com/all.zip",
+                }
+            ],
+        }
+        checkpoint_manager.is_initial_load_needed.return_value = True
+        checkpoint_manager.get_checkpoint.return_value = {}
+        github_client.download_release_asset.return_value = zip_path
+        github_client.stream_zip_contents.return_value = iter([])
+        cve_processor.get_stats.return_value = {
+            "processed": 0,
+            "skipped": 0,
+            "errors": 0,
+        }
+        cve_processor.max_date_updated = None
+
+        instance._process_baseline(
+            github_client=github_client,
+            checkpoint_manager=checkpoint_manager,
+            cve_processor=cve_processor,
+            batch_size=500,
+            ew=ew,
+        )
+
+        assert not os.path.exists(zip_path), (
+            "Temp ZIP was not deleted after successful baseline processing"
+        )
+
+    def test_zip_deleted_when_processing_raises(self, tmp_path):
+        """Temp ZIP must be deleted even when processing throws an exception."""
+        zip_path = _make_temp_zip(tmp_path)
+        assert os.path.exists(zip_path)
+
+        instance = _make_input_instance()
+        github_client = MagicMock()
+        checkpoint_manager = MagicMock()
+        cve_processor = MagicMock()
+        ew = MagicMock()
+
+        github_client.find_baseline_release.return_value = {
+            "tag_name": "cve_2024-01-01_0000Z",
+            "assets": [
+                {
+                    "name": "all_CVEs_at_midnight.zip",
+                    "browser_download_url": "https://example.com/all.zip",
+                }
+            ],
+        }
+        checkpoint_manager.is_initial_load_needed.return_value = True
+        checkpoint_manager.get_checkpoint.return_value = {}
+        github_client.download_release_asset.return_value = zip_path
+        github_client.stream_zip_contents.side_effect = RuntimeError("corrupt zip")
+
+        with pytest.raises(RuntimeError, match="corrupt zip"):
+            instance._process_baseline(
+                github_client=github_client,
+                checkpoint_manager=checkpoint_manager,
+                cve_processor=cve_processor,
+                batch_size=500,
+                ew=ew,
+            )
+
+        assert not os.path.exists(zip_path), (
+            "Temp ZIP was not deleted after baseline processing error"
+        )

--- a/tests/unit/test_zip_cleanup.py
+++ b/tests/unit/test_zip_cleanup.py
@@ -139,3 +139,137 @@ class TestBaselineZipCleanup:
         assert not os.path.exists(zip_path), (
             "Temp ZIP was not deleted after baseline processing error"
         )
+
+
+class TestDeltaZipCleanup:
+    def test_zip_deleted_after_successful_delta(self, tmp_path):
+        """Temp ZIP must be deleted after each delta processes successfully."""
+        zip_path = _make_temp_zip(tmp_path)
+        assert os.path.exists(zip_path)
+
+        instance = _make_input_instance()
+        github_client = MagicMock()
+        checkpoint_manager = MagicMock()
+        cve_processor = MagicMock()
+        ew = MagicMock()
+
+        checkpoint_manager.get_checkpoint.return_value = {
+            "last_release": "cve_2024-01-01_0100Z"
+        }
+        github_client.find_delta_releases_since.return_value = [
+            {
+                "tag_name": "cve_2024-01-01_0200Z",
+                "assets": [
+                    {
+                        "name": "delta_CVEs_at_0200Z.zip",
+                        "browser_download_url": "https://example.com/delta.zip",
+                    }
+                ],
+            }
+        ]
+        github_client.download_release_asset.return_value = zip_path
+        github_client.stream_zip_contents.return_value = iter([])
+        cve_processor.max_date_updated = None
+
+        instance._process_deltas(
+            github_client=github_client,
+            checkpoint_manager=checkpoint_manager,
+            cve_processor=cve_processor,
+            batch_size=500,
+            ew=ew,
+        )
+
+        assert not os.path.exists(zip_path), (
+            "Temp ZIP was not deleted after successful delta processing"
+        )
+
+    def test_zip_deleted_when_delta_raises(self, tmp_path):
+        """Temp ZIP must be deleted even when delta processing throws."""
+        zip_path = _make_temp_zip(tmp_path)
+        assert os.path.exists(zip_path)
+
+        instance = _make_input_instance()
+        github_client = MagicMock()
+        checkpoint_manager = MagicMock()
+        cve_processor = MagicMock()
+        ew = MagicMock()
+
+        checkpoint_manager.get_checkpoint.return_value = {
+            "last_release": "cve_2024-01-01_0100Z"
+        }
+        github_client.find_delta_releases_since.return_value = [
+            {
+                "tag_name": "cve_2024-01-01_0200Z",
+                "assets": [
+                    {
+                        "name": "delta_CVEs_at_0200Z.zip",
+                        "browser_download_url": "https://example.com/delta.zip",
+                    }
+                ],
+            }
+        ]
+        github_client.download_release_asset.return_value = zip_path
+        github_client.stream_zip_contents.side_effect = RuntimeError("corrupt zip")
+
+        with pytest.raises(RuntimeError, match="corrupt zip"):
+            instance._process_deltas(
+                github_client=github_client,
+                checkpoint_manager=checkpoint_manager,
+                cve_processor=cve_processor,
+                batch_size=500,
+                ew=ew,
+            )
+
+        assert not os.path.exists(zip_path), (
+            "Temp ZIP was not deleted after delta processing error"
+        )
+
+    def test_all_zips_cleaned_in_multi_delta_run(self, tmp_path):
+        """All temp ZIPs must be cleaned up when processing multiple deltas."""
+        # Create 3 unique zip files in subdirectories
+        zip_paths = []
+        for i in range(3):
+            subdir = tmp_path / f"delta{i}"
+            subdir.mkdir()
+            zip_paths.append(_make_temp_zip(subdir))
+
+        for p in zip_paths:
+            assert os.path.exists(p)
+
+        instance = _make_input_instance()
+        github_client = MagicMock()
+        checkpoint_manager = MagicMock()
+        cve_processor = MagicMock()
+        ew = MagicMock()
+
+        checkpoint_manager.get_checkpoint.return_value = {
+            "last_release": "cve_2024-01-01_0100Z"
+        }
+        github_client.find_delta_releases_since.return_value = [
+            {
+                "tag_name": f"cve_2024-01-01_0{i}00Z",
+                "assets": [
+                    {
+                        "name": f"delta_CVEs_at_0{i}00Z.zip",
+                        "browser_download_url": f"https://example.com/delta{i}.zip",
+                    }
+                ],
+            }
+            for i in range(2, 5)
+        ]
+        github_client.download_release_asset.side_effect = zip_paths
+        github_client.stream_zip_contents.return_value = iter([])
+        cve_processor.max_date_updated = None
+
+        instance._process_deltas(
+            github_client=github_client,
+            checkpoint_manager=checkpoint_manager,
+            cve_processor=cve_processor,
+            batch_size=500,
+            ew=ew,
+        )
+
+        for p in zip_paths:
+            assert not os.path.exists(p), (
+                f"Temp ZIP {p} was not deleted after multi-delta processing"
+            )


### PR DESCRIPTION
## Summary

- Add `try/finally` cleanup in `_process_baseline` to delete temp ZIP after processing
- Add `try/finally` cleanup in `_process_deltas` to delete temp ZIP after each delta iteration
- Add 5 unit tests covering cleanup on success paths, error paths, and multi-delta runs

## Root Cause

`download_release_asset()` creates temp files via `tempfile.mkstemp(suffix='.zip')` but callers in `cveicu.py` never deleted them. On Splunk Cloud with hourly delta runs, thousands of ZIPs accumulated in `/tmp`, filling the Search Head disk.

**Reported via:** Splunk Support Case #4012420

Closes #4

## Test Plan

- [x] `test_zip_deleted_after_successful_processing` — baseline success path
- [x] `test_zip_deleted_when_processing_raises` — baseline error path
- [x] `test_zip_deleted_after_successful_delta` — delta success path
- [x] `test_zip_deleted_when_delta_raises` — delta error path
- [x] `test_all_zips_cleaned_in_multi_delta_run` — multi-delta loop
- [x] Full test suite: 51 passed, 8 skipped, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)